### PR TITLE
Set number of walkers from runtime.GOMAXPROCS

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -153,7 +153,7 @@ func Walk(root string, walkFn WalkFunc) error {
 	ws.active.Add(1)
 	ws.v <- VisitData{root, info}
 
-	walkers := runtime.GOMAXPROCS
+	walkers := runtime.GOMAXPROCS(0)
 	for i := 0; i < walkers; i++ {
 		go ws.visitChannel()
 	}

--- a/walk.go
+++ b/walk.go
@@ -152,7 +152,7 @@ func Walk(root string, walkFn WalkFunc) error {
 	ws.active.Add(1)
 	ws.v <- VisitData{root, info}
 
-	walkers := 32
+	walkers := 64
 	for i := 0; i < walkers; i++ {
 		go ws.visitChannel()
 	}

--- a/walk.go
+++ b/walk.go
@@ -152,7 +152,7 @@ func Walk(root string, walkFn WalkFunc) error {
 	ws.active.Add(1)
 	ws.v <- VisitData{root, info}
 
-	walkers := 16
+	walkers := 32
 	for i := 0; i < walkers; i++ {
 		go ws.visitChannel()
 	}

--- a/walk.go
+++ b/walk.go
@@ -9,6 +9,7 @@ package walk
 import (
 	"errors"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -152,7 +153,7 @@ func Walk(root string, walkFn WalkFunc) error {
 	ws.active.Add(1)
 	ws.v <- VisitData{root, info}
 
-	walkers := 64
+	walkers := runtime.GOMAXPROCS
 	for i := 0; i < walkers; i++ {
 		go ws.visitChannel()
 	}


### PR DESCRIPTION
I was able to get considerable performance improvements to walking, by increasing this static number on my very large 40 CPU systems with large disk arrays.

It makes sense to set this based on `GOMAXPROCS` so it's tunable for each system more appropriately :)
